### PR TITLE
Make full width of labels clickable

### DIFF
--- a/javascript/base.js
+++ b/javascript/base.js
@@ -286,7 +286,7 @@ loadmap = function(){
 		current: settings.user.type,
 		register: function(id, layer, name) {
 			this.list[id] = layer;
-			addLiAlpha('#mapControl', '<li onclick="javascript:mapLayer.load(\'' + id + '\')"><input type="radio" name="map" value="' + id + '" onchange="javascript:mapLayer.load(\'' + id + '\')" id="map_' + id + '" ' + ((this.current === id) ? 'checked="checked"' : '') + '/> <label for="map_' + id + '">' + name + '</label></li>');
+			addLiAlpha('#mapControl', '<li><input type="radio" name="map" value="' + id + '" onchange="javascript:mapLayer.load(\'' + id + '\')" id="map_' + id + '" ' + ((this.current === id) ? 'checked="checked"' : '') + '/> <label for="map_' + id + '">' + name + '</label></li>');
 		},
 		load: function(id) {
 			if (id !== this.current) {

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -150,13 +150,13 @@ a {
 			padding: 5px;
 			border-top: $border2;
 			display: block;
-			cursor: pointer;
 		}
 		input[type=radio], input[type=checkbox]{
 			display: none;
 		}
 		input+label{
 			cursor: pointer;
+			display: block;
 		}
 		input[type=radio]+label{
 			background: url('/img/radio.png') left center no-repeat;

--- a/template/map.tpl.php
+++ b/template/map.tpl.php
@@ -133,7 +133,7 @@
 			<div class="control" id="saveControl">
 				<div class="title">Save settings</div>
 				<div class="content">
-					<input type="checkbox" id="controlsVisible" <?=$this->settings['controlsVisible'] ? 'checked' : ''?>/><label for="controlsVisible">Show controls by default</label><br/>
+					<input type="checkbox" id="controlsVisible" <?=$this->settings['controlsVisible'] ? 'checked' : ''?>/><label for="controlsVisible">Show controls by default</label>
 					<button onclick="gcookie.set();return false;">Save my settings in a cookie</button> <button onclick="gcookie.unset();return false;">Delete cookie</button>
 					<button onclick="greybox.open('settings');return false;" style="margin-top:3px;">View settings</button>
 				</div>


### PR DESCRIPTION
It often bothers me that clicking just to the right of the text "Move home and center of grid" has no effect, despite a pointer cursor and button-ish appearance. This did work for the map options (no longer useful per #34) due to the `<li onclick="...">`.

Now for all options, the pointer cursor only appears over the block-styled clickable label, which excludes the 5px padding on all four sides belonging to the `li` element. It looked a bit tricky to reassign that padding to various `li` contents.

I tested the SCSS changes by running `scss style.scss`, meanwhile editing the site CSS in Firefox developer tools to achieve the desired effect (couldn't get it to [load locally generated CSS](https://firefox-source-docs.mozilla.org/devtools-user/style_editor/#editing-original-sources)...), and verifying that the two results were equivalent up to punctuation placement. I tested the DOM changes in Firefox developer tools, but haven't executed the updated PHP or Javascript.